### PR TITLE
Update ktools.py to comply with KiCad 8

### DIFF
--- a/ktools.py
+++ b/ktools.py
@@ -27,7 +27,7 @@ def list_coords(format = ""):
         elif format == "python":
             print(f'    fx = brd.FindFootprintByReference("{fp.GetReference()}")')
             print("    if fx is not None:")
-            print(f'        fx.SetPosition(pcbnew.VECTOR2I(pcbnew.wxPoint({vect.x}, {vect.y})))')
+            print(f'        fx.SetPosition(pcbnew.VECTOR2I(pcbnew.wxPoint({vect.x}, {vect.y}).x,pcbnew.VECTOR2I(pcbnew.wxPoint({vect.x}, {vect.y}).y))')
             print(f'        fx.SetOrientation(pcbnew.EDA_ANGLE({orient.AsDegrees()}, pcbnew.DEGREES_T))')
     if format == "python":
         print('    pcbnew.Refresh()')


### PR DESCRIPTION
[Long context intro you might not be interested in]
Thank you for your great tutorials! I got to the "importing Eagle into kicad 7" tutorial and alredy watched some others on your channel. Thank you so so much, greatly appreciated since I am trying to integrate an Arduino Nano with other modules in a single custom PCB (which I dont know if its very wise from production/cost viewpoint but whatever, its for fun and learning). Since I didnt find an already working kicad arduino nano project (schematics and pcb) which Im sure must be floating somewhere on the internet (I dont think Im the first doing this), I am importing eagle files found [here](https://store.arduino.cc/products/arduino-nano?_gl=1*hf0o3e*_up*MQ..*_ga*NTc5MzIxMTkyLjE3MzgwOTczNzI.*_ga_NEXN8H46L5*MTczODA5NzM3Mi4xLjAuMTczODA5NzM3Mi4wLjAuMTQ1NzI1NDI5OQ..) into kicad 8 (ubuntu) following your tutorial and it helped a lot ^_^. Sorry for the long intro, if you have any more wisdom that may help in this endeavor I will be even more eternally grateful.

[Actual Pull Request description]
Working on kicad 8 (ubuntu) I get this error:

pcbnew.VECTOR2I(pcbnew.wxPoint(155867100, 100431600)) Traceback (most recent call last):
  File "/usr/lib/python3.8/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "/usr/lib/python3.8/site-packages/pcbnew.py", line 5209, in __init__
    _pcbnew.VECTOR2I_swiginit(self, _pcbnew.new_VECTOR2I(*args))
TypeError: in method 'new_VECTOR2I', argument 1 of type 'VECTOR2< int > const &' Additional information:
Wrong number or type of arguments for overloaded function 'new_VECTOR2I'.
  Possible C/C++ prototypes are:
    VECTOR2< int >::VECTOR2()
    VECTOR2< int >::VECTOR2(int,int)
    VECTOR2< int >::VECTOR2(VECTOR2< int > const &)